### PR TITLE
Apply aspectFit to all images except profile images

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -273,6 +273,7 @@ body {
     opacity: 0.15;
     flex-shrink: 0;
     transition: opacity 0.3s ease;
+    object-fit: contain;
 }
 
 @keyframes scrollRight {
@@ -474,7 +475,7 @@ body {
 .work-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     transition: var(--transition);
 }
 
@@ -841,7 +842,7 @@ body {
 .app-featured-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 }
 
 .app-placeholder {
@@ -1867,7 +1868,7 @@ body {
     width: 120px;
     height: 120px;
     border-radius: 20px;
-    object-fit: cover;
+    object-fit: contain;
     border: 1px solid var(--color-border);
 }
 
@@ -2542,6 +2543,11 @@ body {
         width: 100%;
         justify-content: center;
     }
+}
+
+/* General image aspectFit styling (excludes profile images) */
+img:not(.profile-image) {
+    object-fit: contain;
 }
 
 /* Social Media Icons */


### PR DESCRIPTION
Apply aspectFit styling to all site images except profile images

- Change object-fit from cover to contain for all app icons, background icons, and featured images
- Add general CSS rule to apply object-fit: contain to all images except profile images
- Preserve object-fit: cover for .profile-image class to maintain circular profile display

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)